### PR TITLE
Smaller track listings in chat

### DIFF
--- a/rdiodj/static/css/style.less
+++ b/rdiodj/static/css/style.less
@@ -413,15 +413,29 @@ img {
 	vertical-align: bottom;
 	overflow-y: auto;
 	overflow-x: hidden;
-	padding: 0 20px;
 }
 
 .chat-messages {
 	margin: 0;
 	list-style-type: none;
 
-	li {
-		padding-left: 20px;
+	.presence {
+		margin: 2% 5%;
+	}
+
+	.chat-message-track {
+		margin: 1% 0;
+		padding: 1% 5%;
+		font-size: 10px;
+		color: white;
+		list-style: none;
+		background-color: rgba(0, 0, 0, 0.25);
+		line-height: 1.4;
+
+		img {
+			padding: 0.5em 0.5em 0.5em 0;
+			border: 0;
+		}
 	}
 }
 
@@ -436,24 +450,6 @@ img {
 	font-size: 12px;
 	margin-right: 0.5em;
 	color: #FFF;
-}
-
-.chat-message-track {
-	margin: 0.5em;
-	padding: 0.75em;
-	font-size: 10px;
-	color: white;
-	list-style-type: disc;
-	background-color: rgba(0, 0, 0, .25);
-
-	span {
-		font-weight: 100;
-		letter-spacing: 1px;
-	}
-
-	.main {
-		width: 100%;
-	}
 }
 
 .chat-track-icon {
@@ -540,6 +536,7 @@ img {
 			margin-bottom: 0.3em;
 		}
 	}
+
 	&:hover .album-info {
 		visibility:visible;
 		opacity:1;

--- a/rdiodj/template/party.html
+++ b/rdiodj/template/party.html
@@ -205,7 +205,7 @@
         <tr>
           <td>
             <a href="<%= trackUrl %>" target="_blank">
-              <img src="<%= iconUrl %>" width=50 height=50 style="padding: 5px; border: 0;">
+              <img src="<%= iconUrl %>" width="35" height="35">
             </a>
           </td>
           <td>


### PR DESCRIPTION
Changed up the chat padding to allow for items to be full-width.
Split styles between .presence (chat/events) and .chat-message-track (played tracks).
Merged styles so they're all under .chat-messages.
Switched margin/padding to % since font-size was changing here. 

Related to a request in #122.

Looks like this: 
![screen shot 2015-05-17 at 2 42 45 pm](https://cloud.githubusercontent.com/assets/394888/7671553/7a1bf732-fca3-11e4-8e8a-3542f6611430.png)
No, Joe Bonamassa does not have a track called "The Ballad Of John Henry (Live From The Royal Albert Hall)lkadsjlka jsdklaj sdlkaj sdlkajs dlkajd slkasjd lakdjs" :smile: 